### PR TITLE
Removed "requests"

### DIFF
--- a/ckanext/requestdata/templates/requestdata/my_requested_data.html
+++ b/ckanext/requestdata/templates/requestdata/my_requested_data.html
@@ -25,7 +25,7 @@
   <div class="requests-main-container">
     {% snippet 'requestdata/snippets/requests_header.html', title='My Requests', total_requests=total_requests %}
 
-    {% snippet 'requestdata/snippets/section_base.html', state='new', title='New requests', requests=requests_new, template_type='user' %}
+    {% snippet 'requestdata/snippets/section_base.html', state='new', title='New', requests=requests_new, template_type='user' %}
     {% snippet 'requestdata/snippets/section_base.html', state='open', title='Open', requests=requests_open, template_type='user' %}
 
     {% if requests_archive %}


### PR DESCRIPTION
Removed "requests" word to align the titles of snippets as for the whole extension.