### PR TITLE
PR quick fix for deleted dataset

### DIFF
--- a/ckanext/requestdata/controllers/user.py
+++ b/ckanext/requestdata/controllers/user.py
@@ -94,9 +94,13 @@ class UserController(BaseController):
                 item['requests'] = count.requests
 
         for item in requests:
-            package = _get_action('package_show', {'id': item['package_id']})
-            package_maintainers_ids = package['maintainer'].split(',')
-            item['title'] = package['title']
+            try:
+                package = _get_action('package_show', {'id': item['package_id']})
+                package_maintainers_ids = package['maintainer'].split(',')
+                item['title'] = package['title']
+            except NotFound, e:
+                # package was not found, possibly deleted
+                continue
             maintainers = []
             for i in package_maintainers_ids:
                 try:


### PR DESCRIPTION
In case the requested dataset was deleted then "_get_action('package_show'..." throws an exception and the page is not rendered.
A more thorough fix should be implemented. This is just to still be able to see the page.